### PR TITLE
Add keyword bracket matching for OCaml

### DIFF
--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -25,6 +25,10 @@
   "<" @open
   "/>" @close)
 
+(parenthesized_expression
+  "begin" @open
+  "end" @close)
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -37,6 +37,10 @@
   "sig" @open
   "end" @close)
 
+(object_expression
+  "object" @open
+  "end" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -29,6 +29,14 @@
   "begin" @open
   "end" @close)
 
+(structure
+  "struct" @open
+  "end" @close)
+
+(signature
+  "sig" @open
+  "end" @close)
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -45,6 +45,10 @@
   "do" @open
   "done" @close)
 
+(try_expression
+  "try" @open
+  "with" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -37,6 +37,10 @@
   "sig" @open
   "end" @close)
 
+(if_expression
+  (then_clause "then" @open)
+  (else_clause "else" @close))
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -41,6 +41,10 @@
   "object" @open
   "end" @close)
 
+(do_clause
+  "do" @open
+  "done" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -24,3 +24,19 @@
 (jsx_element_self_closing
   "<" @open
   "/>" @close)
+
+(let_expression
+  (value_definition "let" @open)
+  "in" @close)
+
+(let_module_expression
+  "let" @open
+  "in" @close)
+
+(let_open_expression
+  "let" @open
+  "in" @close)
+
+(let_exception_expression
+  "let" @open
+  "in" @close)

--- a/languages/mlx/brackets.scm
+++ b/languages/mlx/brackets.scm
@@ -50,11 +50,14 @@
   "with" @close)
 
 (if_expression
-  (then_clause "then" @open)
-  (else_clause "else" @close))
+  (then_clause
+    "then" @open)
+  (else_clause
+    "else" @close))
 
 (let_expression
-  (value_definition "let" @open)
+  (value_definition
+    "let" @open)
   "in" @close)
 
 (let_module_expression

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -25,6 +25,10 @@
   "sig" @open
   "end" @close)
 
+(object_expression
+  "object" @open
+  "end" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -33,6 +33,10 @@
   "do" @open
   "done" @close)
 
+(try_expression
+  "try" @open
+  "with" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -12,3 +12,19 @@
 
 ("\"" @open
   "\"" @close)
+
+(let_expression
+  (value_definition "let" @open)
+  "in" @close)
+
+(let_module_expression
+  "let" @open
+  "in" @close)
+
+(let_open_expression
+  "let" @open
+  "in" @close)
+
+(let_exception_expression
+  "let" @open
+  "in" @close)

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -17,6 +17,14 @@
   "begin" @open
   "end" @close)
 
+(structure
+  "struct" @open
+  "end" @close)
+
+(signature
+  "sig" @open
+  "end" @close)
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -13,6 +13,10 @@
 ("\"" @open
   "\"" @close)
 
+(parenthesized_expression
+  "begin" @open
+  "end" @close)
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -25,6 +25,10 @@
   "sig" @open
   "end" @close)
 
+(if_expression
+  (then_clause "then" @open)
+  (else_clause "else" @close))
+
 (let_expression
   (value_definition "let" @open)
   "in" @close)

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -29,6 +29,10 @@
   "object" @open
   "end" @close)
 
+(do_clause
+  "do" @open
+  "done" @close)
+
 (if_expression
   (then_clause "then" @open)
   (else_clause "else" @close))

--- a/languages/ocaml/brackets.scm
+++ b/languages/ocaml/brackets.scm
@@ -38,11 +38,14 @@
   "with" @close)
 
 (if_expression
-  (then_clause "then" @open)
-  (else_clause "else" @close))
+  (then_clause
+    "then" @open)
+  (else_clause
+    "else" @close))
 
 (let_expression
-  (value_definition "let" @open)
+  (value_definition
+    "let" @open)
   "in" @close)
 
 (let_module_expression


### PR DESCRIPTION
Add bracket matching pairs for OCaml keyword delimiters, enabling highlighting and jump-to-matching-bracket for the following constructs:

- `let` / `in` — local value, module, open, and exception bindings
- `begin` / `end` — parenthesized expression blocks
- `struct` / `end` — module structure bodies
- `sig` / `end` — module signature bodies
- `object` / `end` — object expressions
- `do` / `done` — `for` and `while` loop bodies
- `try` / `with` — exception handlers
- `then` / `else` — conditional branches

All pairs are scoped to their specific tree-sitter nodes, so keywords that appear in multiple contexts (e.g. `with` in both `try...with` and `match...with`) do not produce false matches.

Changes apply to both the `ocaml` and `ocaml-mlx` grammars.