### PR TITLE
Odoc (`.mld`) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 An [OCaml](https://ocaml.org/) extension for [Zed](https://zed.dev).
 
+This extension includes support for:
+
+- OCaml (`.ml`) and OCaml Interface (`.mli`)
+- OCaml MLX (`.mlx`)
+- Reason (`.re` and `.rei`)
+- Dune (`dune`, `dune-project` and `dune-workspace`)
+- Menhir (`.mly`)
+- OCamllex (`.mll`)
+- Odoc (`.mld`)
+
 # Language Server
 
 The extension automatically detects how to start `ocamllsp` based on your project setup, using the following priority order:

--- a/extension.toml
+++ b/extension.toml
@@ -45,3 +45,7 @@ path = "grammars/mlx"
 [grammars.ocamllex]
 repository = "https://github.com/314eter/tree-sitter-ocamllex"
 commit = "c5cf996c23e38a1537069fbe2d4bb83a75fc7b2f"
+
+[grammars.odoc_mld]
+repository = "https://github.com/manenko/tree-sitter-odoc-mld"
+commit = "2eafb2a4732b2029d03534ccb0df9134b2577161"

--- a/languages/ocaml-mld/brackets.scm
+++ b/languages/ocaml-mld/brackets.scm
@@ -1,0 +1,2 @@
+("{" @open "}" @close)
+("[" @open "]" @close)

--- a/languages/ocaml-mld/brackets.scm
+++ b/languages/ocaml-mld/brackets.scm
@@ -1,0 +1,5 @@
+("{" @open
+  "}" @close)
+
+("[" @open
+  "]" @close)

--- a/languages/ocaml-mld/config.toml
+++ b/languages/ocaml-mld/config.toml
@@ -1,0 +1,5 @@
+name = "Odoc"
+grammar = "odoc_mld"
+path_suffixes = ["mld"]
+tab_size = 2
+hard_tabs = false

--- a/languages/ocaml-mld/highlights.scm
+++ b/languages/ocaml-mld/highlights.scm
@@ -1,0 +1,246 @@
+; Headings
+(heading
+  "{" @punctuation.bracket
+  level: (heading_level) @number
+  "}" @punctuation.bracket)
+
+(heading
+  label: (heading_label) @label)
+
+(heading_content) @title
+
+; Code blocks
+(code_block
+  "{[" @punctuation.bracket
+  "]}" @punctuation.bracket)
+
+(tagged_code_block
+  "{" @punctuation.bracket
+  "@" @operator
+  language: (code_language) @label
+  "[" @punctuation.bracket
+  "]}" @punctuation.bracket)
+
+(code_content) @text.literal
+
+; Verbatim blocks
+(verbatim_block
+  "{v" @punctuation.bracket
+  "v}" @punctuation.bracket)
+
+(verbatim_content) @text.literal
+
+; Inline code
+(inline_code
+  "[" @punctuation.bracket
+  "]" @punctuation.bracket)
+
+(inline_code_content) @text.literal
+
+; Styles
+(bold
+  "{b" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(bold
+  content: (_)+ @emphasis.strong)
+
+(italic
+  "{i" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(italic
+  content: (_)+ @emphasis)
+
+(emph
+  "{e" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(emph
+  content: (_)+ @emphasis)
+
+(superscript
+  "{^" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(subscript
+  "{_" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(center
+  "{C" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(left
+  "{L" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(right
+  "{R" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+; References and links
+(ref
+  "{" @punctuation.bracket
+  "!" @operator
+  id: (ref_id) @link_uri
+  "}" @punctuation.bracket)
+
+(ref_with_text
+  "!" @operator
+  id: (ref_id) @link_uri)
+
+(ref_with_text
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(ref_with_text
+  text: (_)+ @link_text)
+
+(link
+  ":" @operator
+  url: (link_url) @link_uri)
+
+(link
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+; Lists
+(ul_bullet) @punctuation.list_marker
+(ol_number) @punctuation.list_marker
+
+(tagged_ul
+  "{ul" @keyword
+  "}" @keyword)
+
+(tagged_ol
+  "{ol" @keyword
+  "}" @keyword)
+
+(list_item
+  "{" @punctuation.bracket
+  (list_dash) @punctuation.list_marker
+  "}" @punctuation.bracket)
+
+(list_item
+  "{li" @keyword
+  "}" @keyword)
+
+; Math and targets
+(math_block
+  "{math" @keyword
+  "}" @keyword)
+
+(math_inline
+  "{m" @keyword
+  "}" @keyword)
+
+(math_content) @text.literal
+
+(target_specific
+  "{%" @keyword
+  "%}" @keyword)
+
+(target_specific
+  target: (target_name) @label
+  ":" @operator)
+
+(target_content) @text.literal
+
+; Directives
+(modules_directive
+  "{!modules:" @keyword
+  "}" @keyword)
+
+(module_name) @type
+(indexlist_directive) @keyword
+
+; Media
+(media_simple
+  "}" @punctuation.bracket)
+
+(media_simple
+  [
+    "{image:"
+    "{image!"
+    "{video:"
+    "{video!"
+    "{audio:"
+    "{audio!"
+  ] @punctuation.bracket)
+
+(media_simple
+  source: (media_source) @link_uri)
+
+(media_with_text
+  "}" @punctuation.bracket)
+
+(media_with_text
+  [
+    "{{image:"
+    "{{image!"
+    "{{video:"
+    "{{video!"
+    "{{audio:"
+    "{{audio!"
+  ] @punctuation.bracket)
+
+(media_with_text
+  source: (media_source) @link_uri)
+
+(media_with_text
+  text: (_)+ @link_text)
+
+; Tags
+(author_tag
+  "@author" @keyword)
+
+(author_tag
+  value: (tag_text) @string)
+
+(since_tag
+  "@since" @keyword)
+
+(since_tag
+  value: (tag_text) @string)
+
+(version_tag
+  "@version" @keyword)
+
+(version_tag
+  value: (tag_text) @string)
+
+(deprecated_tag
+  "@deprecated" @keyword)
+
+(return_tag
+  ["@return" "@returns"] @keyword)
+
+(param_tag
+  "@param" @keyword)
+
+(param_tag
+  name: (param_name) @variable.parameter)
+
+(raise_tag
+  ["@raise" "@raises"] @keyword)
+
+(raise_tag
+  name: (exception_name) @type)
+
+(before_tag
+  "@before" @keyword)
+
+(before_tag
+  version: (word) @string)
+
+(see_tag
+  "@see" @keyword)
+
+(see_tag
+  ref: (see_ref) @link_uri)
+
+(hint_tag) @keyword
+
+; Escapes
+(escape_sequence) @string.escape

--- a/languages/ocaml-mld/highlights.scm
+++ b/languages/ocaml-mld/highlights.scm
@@ -1,0 +1,254 @@
+; Headings
+(heading
+  "{" @punctuation.bracket
+  level: (heading_level) @number
+  "}" @punctuation.bracket)
+
+(heading
+  label: (heading_label) @label)
+
+(heading_content) @title
+
+; Code blocks
+(code_block
+  "{[" @punctuation.bracket
+  "]}" @punctuation.bracket)
+
+(tagged_code_block
+  "{" @punctuation.bracket
+  "@" @operator
+  language: (code_language) @label
+  "[" @punctuation.bracket
+  "]}" @punctuation.bracket)
+
+(code_content) @text.literal
+
+; Verbatim blocks
+(verbatim_block
+  "{v" @punctuation.bracket
+  "v}" @punctuation.bracket)
+
+(verbatim_content) @text.literal
+
+; Inline code
+(inline_code
+  "[" @punctuation.bracket
+  "]" @punctuation.bracket)
+
+(inline_code_content) @text.literal
+
+; Styles
+(bold
+  "{b" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(bold
+  content: (_)+ @emphasis.strong)
+
+(italic
+  "{i" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(italic
+  content: (_)+ @emphasis)
+
+(emph
+  "{e" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(emph
+  content: (_)+ @emphasis)
+
+(superscript
+  "{^" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(subscript
+  "{_" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(center
+  "{C" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(left
+  "{L" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(right
+  "{R" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+; References and links
+(ref
+  "{" @punctuation.bracket
+  "!" @operator
+  id: (ref_id) @link_uri
+  "}" @punctuation.bracket)
+
+(ref_with_text
+  "!" @operator
+  id: (ref_id) @link_uri)
+
+(ref_with_text
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+(ref_with_text
+  text: (_)+ @link_text)
+
+(link
+  ":" @operator
+  url: (link_url) @link_uri)
+
+(link
+  "{" @punctuation.bracket
+  "}" @punctuation.bracket)
+
+; Lists
+(ul_bullet) @punctuation.list_marker
+
+(ol_number) @punctuation.list_marker
+
+(tagged_ul
+  "{ul" @keyword
+  "}" @keyword)
+
+(tagged_ol
+  "{ol" @keyword
+  "}" @keyword)
+
+(list_item
+  "{" @punctuation.bracket
+  (list_dash) @punctuation.list_marker
+  "}" @punctuation.bracket)
+
+(list_item
+  "{li" @keyword
+  "}" @keyword)
+
+; Math and targets
+(math_block
+  "{math" @keyword
+  "}" @keyword)
+
+(math_inline
+  "{m" @keyword
+  "}" @keyword)
+
+(math_content) @text.literal
+
+(target_specific
+  "{%" @keyword
+  "%}" @keyword)
+
+(target_specific
+  target: (target_name) @label
+  ":" @operator)
+
+(target_content) @text.literal
+
+; Directives
+(modules_directive
+  "{!modules:" @keyword
+  "}" @keyword)
+
+(module_name) @type
+
+(indexlist_directive) @keyword
+
+; Media
+(media_simple
+  "}" @punctuation.bracket)
+
+(media_simple
+  [
+    "{image:"
+    "{image!"
+    "{video:"
+    "{video!"
+    "{audio:"
+    "{audio!"
+  ] @punctuation.bracket)
+
+(media_simple
+  source: (media_source) @link_uri)
+
+(media_with_text
+  "}" @punctuation.bracket)
+
+(media_with_text
+  [
+    "{{image:"
+    "{{image!"
+    "{{video:"
+    "{{video!"
+    "{{audio:"
+    "{{audio!"
+  ] @punctuation.bracket)
+
+(media_with_text
+  source: (media_source) @link_uri)
+
+(media_with_text
+  text: (_)+ @link_text)
+
+; Tags
+(author_tag
+  "@author" @keyword)
+
+(author_tag
+  value: (tag_text) @string)
+
+(since_tag
+  "@since" @keyword)
+
+(since_tag
+  value: (tag_text) @string)
+
+(version_tag
+  "@version" @keyword)
+
+(version_tag
+  value: (tag_text) @string)
+
+(deprecated_tag
+  "@deprecated" @keyword)
+
+(return_tag
+  [
+    "@return"
+    "@returns"
+  ] @keyword)
+
+(param_tag
+  "@param" @keyword)
+
+(param_tag
+  name: (param_name) @variable.parameter)
+
+(raise_tag
+  [
+    "@raise"
+    "@raises"
+  ] @keyword)
+
+(raise_tag
+  name: (exception_name) @type)
+
+(before_tag
+  "@before" @keyword)
+
+(before_tag
+  version: (word) @string)
+
+(see_tag
+  "@see" @keyword)
+
+(see_tag
+  ref: (see_ref) @link_uri)
+
+(hint_tag) @keyword
+
+; Escapes
+(escape_sequence) @string.escape

--- a/languages/ocaml-mld/injections.scm
+++ b/languages/ocaml-mld/injections.scm
@@ -1,0 +1,7 @@
+((code_block
+  (code_content) @injection.content)
+  (#set! injection.language "ocaml"))
+
+((tagged_code_block
+  language: (code_language) @injection.language
+  content: (code_content) @injection.content))

--- a/languages/ocaml-mld/injections.scm
+++ b/languages/ocaml-mld/injections.scm
@@ -1,0 +1,7 @@
+((code_block
+  (code_content) @injection.content)
+  (#set! injection.language "ocaml"))
+
+(tagged_code_block
+  language: (code_language) @injection.language
+  content: (code_content) @injection.content)


### PR DESCRIPTION
Add support for `.mld` files, used by [odoc](https://ocaml.github.io/odoc/odoc/odoc_for_authors.html).

<img width="630" height="195" alt="image" src="https://github.com/user-attachments/assets/6d53d0f6-9e8e-4c97-8a07-69e936da237e" />

<img width="653" height="267" alt="image" src="https://github.com/user-attachments/assets/1ed80a4d-8cc4-489e-aefc-8a77e2d0f1bc" />

<img width="497" height="193" alt="image" src="https://github.com/user-attachments/assets/aa8b5c2b-75c2-417b-9109-db3f9ca42f00" />
