### PR TITLE
Add comment language support

### DIFF
--- a/languages/reason-interface/injections.scm
+++ b/languages/reason-interface/injections.scm
@@ -1,0 +1,3 @@
+; Support for https://github.com/thedadams/zed-comment
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/languages/reason/injections.scm
+++ b/languages/reason/injections.scm
@@ -1,0 +1,3 @@
+; Support for https://github.com/thedadams/zed-comment
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
If a user has the [zed-comment](https://github.com/thedadams/zed-comment) language extension installed, this change allows comments like `// TODO: testing` to be highlighted, in reason.