### PR TITLE
Fix Dune native package management

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,8 +12,8 @@ languages = ["OCaml", "OCaml Interface", "OCaml MLX", "Reason"]
 
 [[capabilities]]
 kind = "process:exec"
-command = "**"
-args = ["pkg", "enabled"]
+command = "*"
+args = ["pkg", "enabled", "--root", "*"]
 
 [grammars.ocaml]
 repository = "https://github.com/tree-sitter/tree-sitter-ocaml"


### PR DESCRIPTION
## Summary

- use Zed's supported `*` wildcard for the Dune probe executable
- authorize the `--root <worktree>` arguments added by #38

## Problem

The Dune package-management probe is currently rejected by Zed's extension capability checks before `dune` is executed.

Zed only treats `*` as the command wildcard; `**` is matched as a literal command name. Process arguments are also matched positionally and exactly unless a wildcard is present, but the manifest still authorizes only `pkg enabled` while the extension now runs `pkg enabled --root <worktree>`.

The resulting process error is converted to `false` by `is_ok_and`, so the extension silently falls through to `opam exec -- ocamllsp`.

## Validation

- reproduced the fallback to `opam` with extension 0.4.0 in a Dune package-management project
- verified `dune pkg enabled --root <worktree>` exits successfully
- built the extension with `cargo check` and for `wasm32-wasip2` in release mode
- installed the patched extension locally and confirmed Zed starts `dune tools exec ocamllsp`

Closes #54.

Follow-up to #37 and #38.
